### PR TITLE
✨ Add routine module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 *.code-workspace
+*mock*
+*test*
+*working*
+philo
 
 # Prerequisites
 *.d

--- a/philo/Makefile
+++ b/philo/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/09/16 12:01:03 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/09/17 16:57:47 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/09/18 09:38:15 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -15,7 +15,8 @@ NAME = philo
 SRCS =                              \
 	main.c 							\
 	init.c							\
-	routine.c
+	routine.c						\
+	threads.c
 
 OBJS = $(SRCS:.c=.o)
 

--- a/philo/Makefile
+++ b/philo/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/09/16 12:01:03 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/09/17 16:04:36 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/09/17 16:57:47 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,12 +14,14 @@ NAME = philo
 
 SRCS =                              \
 	main.c 							\
-	init.c
+	init.c							\
+	routine.c
 
 OBJS = $(SRCS:.c=.o)
 
 CC = cc 
 CFLAGS = -Wall -Werror -Wextra -g
+LDFLAGS = -lpthread
 DEBUG_FLAGS = -Wall -Werror -Wextra -fsanitize=address
 
 all: $(NAME)
@@ -28,10 +30,10 @@ all: $(NAME)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(NAME): $(OBJS)
-	$(CC) $(CFLAGS) $(OBJS) -o $(NAME)
+	$(CC) $(CFLAGS) $(OBJS) -o $(NAME) $(LDFLAGS)
 
 debug: $(OBJS)
-	$(CC) $(DEBUG_FLAGS) $(CFLAGS) $(OBJS) -o $(NAME)
+	$(CC) $(DEBUG_FLAGS) $(CFLAGS) $(OBJS) -o $(NAME) $(LDFLAGS)
 
 clean:
 	rm -f $(OBJS)

--- a/philo/init.c
+++ b/philo/init.c
@@ -6,17 +6,17 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 15:19:24 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/17 16:22:53 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 09:28:39 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 # include "philo.h"
 
-static uint64_t get_time(void)
+uint64_t get_time(void)
 {
     struct timeval time;
     gettimeofday(&time, NULL);
-    return (uint64_t)time.tv_sec * 1000000 + time.tv_usec;
+    return (uint64_t)time.tv_sec * 1000 + time.tv_usec / 1000;
 }
 
 t_table *init_table(int philos, int t_die, int t_eat, int t_sleep, int n_meals)
@@ -37,6 +37,7 @@ t_table *init_table(int philos, int t_die, int t_eat, int t_sleep, int n_meals)
     {
         table->philos[i].id = i;
         table->philos[i].n_meals = 0;
+        table->philos[i].t_start = table->t_start;
         table->philos[i].t_last_meal = table->t_start;
         pthread_mutex_init(&table->philos[i].fork, NULL);
         i++;

--- a/philo/main.c
+++ b/philo/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/17 16:08:59 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/17 16:43:38 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,8 @@ int main(int argc, char **argv)
     t_table *table;
     //TODO input_validation
     table = init_table(atoi(argv[1]), atoi(argv[2]), atoi(argv[3]), atoi(argv[4]), atoi(argv[5]));
+    handle_routine(table);
+    // clean_data()
     
     return (0);
 }

--- a/philo/philo.h
+++ b/philo/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 09:26:21 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 09:38:01 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,7 @@ typedef struct s_table
 /* init */
 uint64_t get_time(void);
 t_table *init_table(int philos, int t_die, int t_eat, int t_sleep, int n_meals);
+void *routine(void *arg);
 void handle_routine(t_table *table);
 
 #endif /* PHILO_H */

--- a/philo/philo.h
+++ b/philo/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/17 16:53:09 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 09:26:21 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,7 @@ typedef struct t_philo
 {
     int id;
     int n_meals;
+    uint64_t t_start;
     uint64_t t_last_meal;
     pthread_t th;
     pthread_mutex_t fork;
@@ -50,6 +51,7 @@ typedef struct s_table
 } t_table;
 
 /* init */
+uint64_t get_time(void);
 t_table *init_table(int philos, int t_die, int t_eat, int t_sleep, int n_meals);
 void handle_routine(t_table *table);
 

--- a/philo/philo.h
+++ b/philo/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/17 16:08:24 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/17 16:53:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,7 @@ typedef struct t_philo
     int id;
     int n_meals;
     uint64_t t_last_meal;
+    pthread_t th;
     pthread_mutex_t fork;
 } t_philo;
 
@@ -50,5 +51,6 @@ typedef struct s_table
 
 /* init */
 t_table *init_table(int philos, int t_die, int t_eat, int t_sleep, int n_meals);
+void handle_routine(t_table *table);
 
 #endif /* PHILO_H */

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -6,13 +6,21 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 09:25:25 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 09:37:31 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 # include "philo.h"
 
-void eat(t_philo *philo)
+static void go_sleep(t_philo *philo)
+{
+    uint64_t t_now;
+
+    t_now = get_time();
+    printf("%ld %d is sleeping\n", t_now - philo->t_start, philo->id);
+}
+
+static void eat(t_philo *philo)
 {
     uint64_t t_now;
 
@@ -22,37 +30,21 @@ void eat(t_philo *philo)
     pthread_mutex_unlock(&philo->fork);
 }
 
-static void *routine(void *arg)
+static void think(t_philo *philo)
+{
+    uint64_t t_now;
+
+    t_now = get_time();
+    printf("%ld %d is thinking\n", t_now - philo->t_start, philo->id);
+}
+
+void *routine(void *arg)
 {
     t_philo *philo;
 
     philo = (t_philo *)arg;
     eat(philo);
-    //go_sleep(philo);
-    //think(philo);  
+    go_sleep(philo);
+    think(philo);
     return(NULL);
-}
-
-static void create_threads(t_table *table)
-{
-    int i;
-    
-    i = 0;
-    while (i < table->n_philos)
-    {
-        pthread_create(&table->philos[i].th, NULL, routine, &table->philos[i]);
-        i++;
-    }
-}
-
-void handle_routine(t_table *table)
-{
-    int i;
-    create_threads(table);
-    i = 0;
-    while (i < table->n_philos)
-    {
-        pthread_join(table->philos[i].th, NULL);
-        i++;
-    }
 }

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -1,0 +1,58 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   routine.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/09/18 09:25:25 by pmarkaid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+# include "philo.h"
+
+void eat(t_philo *philo)
+{
+    uint64_t t_now;
+
+    t_now = get_time();
+    pthread_mutex_lock(&philo->fork);
+    printf("%ld %d is eating\n", t_now - philo->t_start, philo->id);
+    pthread_mutex_unlock(&philo->fork);
+}
+
+static void *routine(void *arg)
+{
+    t_philo *philo;
+
+    philo = (t_philo *)arg;
+    eat(philo);
+    //go_sleep(philo);
+    //think(philo);  
+    return(NULL);
+}
+
+static void create_threads(t_table *table)
+{
+    int i;
+    
+    i = 0;
+    while (i < table->n_philos)
+    {
+        pthread_create(&table->philos[i].th, NULL, routine, &table->philos[i]);
+        i++;
+    }
+}
+
+void handle_routine(t_table *table)
+{
+    int i;
+    create_threads(table);
+    i = 0;
+    while (i < table->n_philos)
+    {
+        pthread_join(table->philos[i].th, NULL);
+        i++;
+    }
+}

--- a/philo/threads.c
+++ b/philo/threads.c
@@ -1,0 +1,37 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   threads.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
+/*   Updated: 2024/09/18 09:37:49 by pmarkaid         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "philo.h"
+
+static void create_threads(t_table *table)
+{
+    int i;
+    
+    i = 0;
+    while (i < table->n_philos)
+    {
+        pthread_create(&table->philos[i].th, NULL, routine, &table->philos[i]);
+        i++;
+    }
+}
+
+void handle_routine(t_table *table)
+{
+    int i;
+    create_threads(table);
+    i = 0;
+    while (i < table->n_philos)
+    {
+        pthread_join(table->philos[i].th, NULL);
+        i++;
+    }
+}


### PR DESCRIPTION
This update implements the MVP for the routine module. Each philo will eat, think and eat and the message will be printed in the terminal.

The module starts creating a thread per philosopher and calling to the routine function. This will call to the eat, sleep and think functions so the messages are printed. The fork is mutexed for eating, the rest is just a message for now.

Still there is no actual wait time and the routine is just called once (vs n_meals or infinite loop).