### PR TITLE
✨ feat: handle wait and n meals

### DIFF
--- a/philo/init.c
+++ b/philo/init.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 15:19:24 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 09:28:39 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 14:09:34 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ t_table *init_table(int philos, int t_die, int t_eat, int t_sleep, int n_meals)
     while (i < philos)
     {
         table->philos[i].id = i;
+        table->philos[i].table = table;
         table->philos[i].n_meals = 0;
         table->philos[i].t_start = table->t_start;
         table->philos[i].t_last_meal = table->t_start;

--- a/philo/philo.h
+++ b/philo/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 09:38:01 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 14:14:47 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,11 +20,12 @@
 # include <pthread.h>       // pthread functions
 # include <stdint.h>        // uint64_t
 
-
+typedef struct s_table t_table;
 typedef struct t_philo
 {
     int id;
     int n_meals;
+    t_table *table;
     uint64_t t_start;
     uint64_t t_last_meal;
     pthread_t th;

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -6,27 +6,29 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 09:37:31 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 14:15:27 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 # include "philo.h"
 
-static void go_sleep(t_philo *philo)
+static void go_sleep(t_philo *philo, int t_sleep)
 {
     uint64_t t_now;
 
     t_now = get_time();
     printf("%ld %d is sleeping\n", t_now - philo->t_start, philo->id);
+    usleep(t_sleep * 1000);
 }
 
-static void eat(t_philo *philo)
+static void eat(t_philo *philo, int t_eat)
 {
     uint64_t t_now;
 
     t_now = get_time();
     pthread_mutex_lock(&philo->fork);
     printf("%ld %d is eating\n", t_now - philo->t_start, philo->id);
+    usleep(t_eat * 1000);
     pthread_mutex_unlock(&philo->fork);
 }
 
@@ -40,11 +42,11 @@ static void think(t_philo *philo)
 
 void *routine(void *arg)
 {
-    t_philo *philo;
+    t_philo *philo = (t_philo *)arg; 
+    t_table *table = philo->table;  
 
-    philo = (t_philo *)arg;
-    eat(philo);
-    go_sleep(philo);
+    eat(philo, table->t_eat);
+    go_sleep(philo, table->t_sleep);
     think(philo);
     return(NULL);
 }

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 14:15:27 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 14:35:00 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,6 +30,8 @@ static void eat(t_philo *philo, int t_eat)
     printf("%ld %d is eating\n", t_now - philo->t_start, philo->id);
     usleep(t_eat * 1000);
     pthread_mutex_unlock(&philo->fork);
+    philo->t_last_meal = get_time();
+    philo->n_meals++;
 }
 
 static void think(t_philo *philo)
@@ -45,8 +47,16 @@ void *routine(void *arg)
     t_philo *philo = (t_philo *)arg; 
     t_table *table = philo->table;  
 
-    eat(philo, table->t_eat);
-    go_sleep(philo, table->t_sleep);
-    think(philo);
+    while(1)
+    {
+        eat(philo, table->t_eat);
+        if(table->n_meals > 0)
+            {
+                if(philo->n_meals == table->n_meals)
+                break;
+            }
+        go_sleep(philo, table->t_sleep);
+        think(philo);
+    }
     return(NULL);
 }

--- a/philo/threads.c
+++ b/philo/threads.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 09:37:49 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 14:16:28 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ static void create_threads(t_table *table)
     i = 0;
     while (i < table->n_philos)
     {
-        pthread_create(&table->philos[i].th, NULL, routine, &table->philos[i]);
+        pthread_create(&table->philos[i].th, NULL, routine, (void *)&table->philos[i]);
         i++;
     }
 }


### PR DESCRIPTION
This update adds the waiting step to the routines and stops when `n_meals` are fulfilled.

A major rework of the struct was needed to give philos access to `t_eat` like variables. I create a pointer to the table itself in each philo. Another option is to copy all time variables into the `t_philo`. I don't like any of those solutions but this works, so I let it like this for now.

We evaluate `n_meals` inside the routine function, so the thread itself can exit. Maybe must be added in the monitoring thread. It works like this.