### PR TITLE
✨ feat: take second fork

### DIFF
--- a/philo/routine.c
+++ b/philo/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 14:56:50 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 15:23:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,13 +27,29 @@ static void eat(t_philo *philo, int t_eat)
     int nb_philo;
 
     nb_philo = philo->table->n_philos;
-    pthread_mutex_lock(&philo->fork);
-    pthread_mutex_lock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
+    if(philo->id % 2 == 0)
+    {
+        pthread_mutex_lock(&philo->fork);
+        pthread_mutex_lock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
+    }
+    else
+    {
+        pthread_mutex_lock(&philo->table->philos[(philo->id - 1) % nb_philo].fork);
+        pthread_mutex_lock(&philo->fork);
+    }
     t_now = get_time();
     printf("%ld %d is eating\n", t_now - philo->t_start, philo->id + 1);
     usleep(t_eat * 1000);
-    pthread_mutex_unlock(&philo->fork);
-    pthread_mutex_unlock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
+    if (philo->id % 2 == 0)
+    {
+        pthread_mutex_unlock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
+        pthread_mutex_unlock(&philo->fork);
+    }
+    else
+    {
+        pthread_mutex_unlock(&philo->fork);
+        pthread_mutex_unlock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
+    }
     philo->t_last_meal = get_time();
     philo->n_meals++;
 }

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 14:48:59 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 14:56:50 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ static void go_sleep(t_philo *philo, int t_sleep)
     uint64_t t_now;
 
     t_now = get_time();
-    printf("%ld %d is sleeping\n", t_now - philo->t_start, philo->id);
+    printf("%ld %d is sleeping\n", t_now - philo->t_start, philo->id + 1);
     usleep(t_sleep * 1000);
 }
 
@@ -27,10 +27,10 @@ static void eat(t_philo *philo, int t_eat)
     int nb_philo;
 
     nb_philo = philo->table->n_philos;
-    t_now = get_time();
     pthread_mutex_lock(&philo->fork);
     pthread_mutex_lock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
-    printf("%ld %d is eating\n", t_now - philo->t_start, philo->id);
+    t_now = get_time();
+    printf("%ld %d is eating\n", t_now - philo->t_start, philo->id + 1);
     usleep(t_eat * 1000);
     pthread_mutex_unlock(&philo->fork);
     pthread_mutex_unlock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
@@ -43,7 +43,7 @@ static void think(t_philo *philo)
     uint64_t t_now;
 
     t_now = get_time();
-    printf("%ld %d is thinking\n", t_now - philo->t_start, philo->id);
+    printf("%ld %d is thinking\n", t_now - philo->t_start, philo->id + 1);
 }
 
 void *routine(void *arg)

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 14:35:00 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 14:48:59 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,12 +24,16 @@ static void go_sleep(t_philo *philo, int t_sleep)
 static void eat(t_philo *philo, int t_eat)
 {
     uint64_t t_now;
+    int nb_philo;
 
+    nb_philo = philo->table->n_philos;
     t_now = get_time();
     pthread_mutex_lock(&philo->fork);
+    pthread_mutex_lock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
     printf("%ld %d is eating\n", t_now - philo->t_start, philo->id);
     usleep(t_eat * 1000);
     pthread_mutex_unlock(&philo->fork);
+    pthread_mutex_unlock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
     philo->t_last_meal = get_time();
     philo->n_meals++;
 }

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 15:23:09 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 15:26:10 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,7 @@ static void eat(t_philo *philo, int t_eat)
     }
     else
     {
-        pthread_mutex_lock(&philo->table->philos[(philo->id - 1) % nb_philo].fork);
+        pthread_mutex_lock(&philo->table->philos[(philo->id + 1) % nb_philo].fork);
         pthread_mutex_lock(&philo->fork);
     }
     t_now = get_time();


### PR DESCRIPTION
Implement the logic of the second fork mutex.

Philos lock their fork and the one from their neighbour. Theirs is the left one and the neighbors would be the right one. In the case of the last philo, the right one is the number 1 (circular table).

Instead of just locking (with mutex) their fork and later the right one, we implement a logic of odd-even philosophers, where even ones first secure the right fork and then their own. The odd ones do the opposite so most likely they will wait for the even one to finish, **without locking the other fork**.

This shall avoid deadlocks.