### PR TITLE
✨ feat: monitoring thread

### DIFF
--- a/philo/init.c
+++ b/philo/init.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 15:19:24 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 14:09:34 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 20:42:23 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,7 @@ t_table *init_table(int philos, int t_die, int t_eat, int t_sleep, int n_meals)
 
     i = 0;
     table = (t_table *)malloc(sizeof(t_table));
+    table->kitchen_open = 1;
     table->n_philos = philos;
     table->t_die = t_die;
     table->t_eat = t_eat;

--- a/philo/philo.h
+++ b/philo/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 14:14:47 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 20:41:12 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,11 +42,13 @@ typedef enum e_status
 
 typedef struct s_table
 {
+    int kitchen_open;
     int n_philos;
     int t_die;
     int t_eat;
     int t_sleep;
     int n_meals;
+    pthread_t waiter;
     t_philo *philos;
     uint64_t t_start;    
 } t_table;

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 15:26:10 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 20:41:45 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,7 @@ void *routine(void *arg)
     t_philo *philo = (t_philo *)arg; 
     t_table *table = philo->table;  
 
-    while(1)
+    while(table->kitchen_open)
     {
         eat(philo, table->t_eat);
         if(table->n_meals > 0)

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 20:41:45 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 21:08:28 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,8 +75,10 @@ void *routine(void *arg)
                 if(philo->n_meals == table->n_meals)
                 break;
             }
-        go_sleep(philo, table->t_sleep);
-        think(philo);
+        if(table->kitchen_open)
+            go_sleep(philo, table->t_sleep);
+        if(table->kitchen_open)
+            think(philo);
     }
     return(NULL);
 }

--- a/philo/threads.c
+++ b/philo/threads.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 20:51:31 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 21:01:18 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ static void *monitor(void *arg)
             if((t_now - table->philos[i].t_last_meal) > (uint64_t)table->t_die)
             {
                 table->kitchen_open = 0;
-                printf("%ld %d had died\n", t_now, i + 1);
+                printf("%ld %d died\n", t_now - table->t_start, i + 1);
                 return NULL;
             }
             i++;
@@ -42,7 +42,7 @@ static void create_threads(t_table *table)
     int i;
     
     i = 0;
-    pthread_create(&table->waiter, NULL, monitor, (void *)&table);
+    pthread_create(&table->waiter, NULL, monitor, (void *)table);
     while (i < table->n_philos)
     {
         pthread_create(&table->philos[i].th, NULL, routine, (void *)&table->philos[i]);

--- a/philo/threads.c
+++ b/philo/threads.c
@@ -6,17 +6,43 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 14:16:28 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 20:51:31 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
+
+static void *monitor(void *arg)
+{
+    int i;
+    uint64_t t_now;
+    t_table *table = (t_table *)arg;
+
+    while (table->kitchen_open)
+    {
+        i = 0;
+        while (i < table->n_philos)
+        {
+            t_now = get_time();
+            if((t_now - table->philos[i].t_last_meal) > (uint64_t)table->t_die)
+            {
+                table->kitchen_open = 0;
+                printf("%ld %d had died\n", t_now, i + 1);
+                return NULL;
+            }
+            i++;
+        }
+        usleep(1000);
+    }
+    return(NULL);
+}
 
 static void create_threads(t_table *table)
 {
     int i;
     
     i = 0;
+    pthread_create(&table->waiter, NULL, monitor, (void *)&table);
     while (i < table->n_philos)
     {
         pthread_create(&table->philos[i].th, NULL, routine, (void *)&table->philos[i]);
@@ -34,4 +60,5 @@ void handle_routine(t_table *table)
         pthread_join(table->philos[i].th, NULL);
         i++;
     }
+    pthread_join(table->waiter, NULL);
 }

--- a/philo/threads.c
+++ b/philo/threads.c
@@ -6,11 +6,25 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/18 21:01:18 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/18 21:36:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
+
+static int all_philos_full(t_table *table)
+{
+    int i;
+
+    i = 0;
+    while (i < table->n_philos)
+    {
+        if(table->philos[i].n_meals < table->n_meals)
+            return(0);
+        i++;
+    }
+    return(1);
+}
 
 static void *monitor(void *arg)
 {
@@ -24,6 +38,8 @@ static void *monitor(void *arg)
         while (i < table->n_philos)
         {
             t_now = get_time();
+            if(all_philos_full(table))
+                return(NULL);
             if((t_now - table->philos[i].t_last_meal) > (uint64_t)table->t_die)
             {
                 table->kitchen_open = 0;


### PR DESCRIPTION
Add a monitoring thread to check if philos dies of starvation.

This update adds a new thread called `waiter` that constantly checks the time difference between each philosopher's `t_last_meal` and the current time. The simulations print a message and stop if the time difference exceeds the t_die parameter.

If `n_meals` is set, the thread exits when all philosphers are full.