### PR TITLE
♻️ refactor: add meal mutex and improve mutex handling

### DIFF
--- a/philo/include/philo.h
+++ b/philo/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 15:24:09 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 15:59:58 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,6 @@ typedef struct t_philo
 	int					id;
 	int					n_meals;
 	t_table				*table;
-	uint64_t			t_start;
 	uint64_t			t_last_meal;
 	pthread_t			th;
 	pthread_mutex_t		fork;

--- a/philo/include/philo.h
+++ b/philo/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 15:59:58 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 16:03:17 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,6 +49,7 @@ typedef struct s_table
 	int					n_meals;
 	pthread_t			waiter;
 	pthread_mutex_t		microphone;
+	pthread_mutex_t		meal;
 	t_philo				*philos;
 	uint64_t			t_start;
 }						t_table;

--- a/philo/include/philo.h
+++ b/philo/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 16:03:17 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 22:12:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,5 +64,6 @@ void					lock_forks(t_philo *philo, int id);
 void					unlock_forks(t_philo *philo, int id);
 void					clean_data(t_table *table);
 void					microphone(t_table *table, char *msg, int id);
+int is_kitchen_open(t_table *table);
 
 #endif /* PHILO_H */

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 16:00:26 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 16:08:34 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -77,6 +77,7 @@ t_table	*init_table(char **argv)
 		i++;
 	}
 	pthread_mutex_init(&table->microphone, NULL);
+	pthread_mutex_init(&table->meal, NULL);
 	return (table);
 }
 

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,23 +6,29 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 21:28:29 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 22:13:40 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
 
+int is_kitchen_open(t_table *table)
+{
+    int open;
+
+    pthread_mutex_lock(&table->meal);
+    open = table->kitchen_open;
+    pthread_mutex_unlock(&table->meal);
+
+    return open;
+}
+
 void	microphone(t_table *table, char *msg, int id)
 {
 	uint64_t	t_now;
 
-	pthread_mutex_lock(&table->meal);  // or a dedicated mutex for kitchen_open
-	if (!table->kitchen_open)
-	{
-		pthread_mutex_unlock(&table->meal);
+    if(!is_kitchen_open(table))
 		return;
-	}
-	pthread_mutex_unlock(&table->meal);
 	pthread_mutex_lock(&table->microphone);
 	t_now = get_time();
 	printf("%ld %d %s\n", t_now - table->t_start, id + 1, msg);
@@ -100,7 +106,6 @@ int	main(int argc, char **argv)
 	if (argc == 5)
 		argv[5] = "0";
 	table = init_table(argv);
-	printf("n_meals is %d\n", table->n_meals);
 	handle_routine(table);
 	clean_data(table);
 	return (0);

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 15:46:13 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 16:00:26 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,7 +72,6 @@ t_table	*init_table(char **argv)
 		table->philos[i].id = i;
 		table->philos[i].table = table;
 		table->philos[i].n_meals = 0;
-		table->philos[i].t_start = table->t_start;
 		table->philos[i].t_last_meal = table->t_start;
 		pthread_mutex_init(&table->philos[i].fork, NULL);
 		i++;

--- a/philo/src/main.c
+++ b/philo/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 16:08:34 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 21:28:29 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,8 +16,13 @@ void	microphone(t_table *table, char *msg, int id)
 {
 	uint64_t	t_now;
 
+	pthread_mutex_lock(&table->meal);  // or a dedicated mutex for kitchen_open
 	if (!table->kitchen_open)
-		return ;
+	{
+		pthread_mutex_unlock(&table->meal);
+		return;
+	}
+	pthread_mutex_unlock(&table->meal);
 	pthread_mutex_lock(&table->microphone);
 	t_now = get_time();
 	printf("%ld %d %s\n", t_now - table->t_start, id + 1, msg);
@@ -95,6 +100,7 @@ int	main(int argc, char **argv)
 	if (argc == 5)
 		argv[5] = "0";
 	table = init_table(argv);
+	printf("n_meals is %d\n", table->n_meals);
 	handle_routine(table);
 	clean_data(table);
 	return (0);

--- a/philo/src/routine.c
+++ b/philo/src/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 21:36:59 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 22:14:31 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,14 +48,9 @@ void	*routine(void *arg)
 	table = philo->table;
 	while (1)
 	{
-		microphone(table, "is thinking", philo->id);
-		pthread_mutex_lock(&table->meal);
-		if (!table->kitchen_open)
-		{
-			pthread_mutex_unlock(&table->meal);
+		if (!is_kitchen_open(table))
 			break;
-		}
-		pthread_mutex_unlock(&table->meal);
+		microphone(table, "is thinking", philo->id);
 		eat(philo, table->t_eat);
 		pthread_mutex_lock(&table->meal);
 		if (table->n_meals > 0 && philo->n_meals >= table->n_meals)

--- a/philo/src/routine.c
+++ b/philo/src/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 15:47:13 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 16:05:01 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,11 +24,13 @@ static void	ft_usleep(uint64_t sleep_time)
 static void	eat(t_philo *philo, int t_eat)
 {
 	lock_forks(philo, philo->id);
+	pthread_mutex_lock(&philo->table->meal);
+	philo->t_last_meal = get_time();
+	philo->n_meals++;
+	pthread_mutex_unlock(&philo->table->meal);
 	microphone(philo->table, "is eating", philo->id);
 	ft_usleep(t_eat);
 	unlock_forks(philo, philo->id);
-	philo->t_last_meal = get_time();
-	philo->n_meals++;
 }
 
 static void	go_sleep(t_philo *philo, int t_sleep)

--- a/philo/src/threads.c
+++ b/philo/src/threads.c
@@ -6,67 +6,72 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 21:48:15 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 22:12:59 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
 
-static int	all_philos_full(t_table *table)
+static int all_philos_full(t_table *table)
 {
-	int	i;
+    int i;
 
-	i = 0;
-	if(table->n_meals == 0)
-		return(0);
-	while (i < table->n_philos)
-	{
-		if (table->philos[i].n_meals < table->n_meals)
-			return (0);
-		i++;
-	}
-	return (1);
+    if (table->n_meals == 0)
+         return 0;
+    pthread_mutex_lock(&table->meal);
+    i = 0;
+    while (i < table->n_philos)
+    {
+        if (table->philos[i].n_meals < table->n_meals)
+        {
+            pthread_mutex_unlock(&table->meal);
+            return 0;
+        }
+        i++;
+    }
+    table->kitchen_open = 0;
+    pthread_mutex_unlock(&table->meal);
+    return 1;
 }
 
-static void	*monitor(void *arg)
+static int philo_is_dead(t_table *table)
 {
-	int			i;
-	uint64_t	t_now;
-	t_table		*table;
+    int i;
+    uint64_t t_now;
 
-	table = (t_table *)arg;
-	while (1)
-	{
-		pthread_mutex_lock(&table->meal);
-		if (!table->kitchen_open)
-		{
+    i = 0;
+    t_now = get_time();
+    while (i < table->n_philos)
+    {
+        pthread_mutex_lock(&table->meal);
+        if ((t_now - table->philos[i].t_last_meal) > (uint64_t)table->t_die)
+        {
+			table->kitchen_open = 0;
+			microphone(table, "died", i);
 			pthread_mutex_unlock(&table->meal);
-			break;
-		}
-		pthread_mutex_unlock(&table->meal);
-		i = 0;
-		while (i < table->n_philos)
-		{
-			pthread_mutex_lock(&table->meal);
-			if (all_philos_full(table))
-			{
-				table->kitchen_open = 0;
-				pthread_mutex_unlock(&table->meal);
-				break;
-			}
-			t_now = get_time();
-			if ((t_now - table->philos[i].t_last_meal) > (uint64_t)table->t_die)
-			{
-				microphone(table, "died", i);
-				table->kitchen_open = 0;
-				pthread_mutex_unlock(&table->meal);
-				return (NULL);
-			}
-			pthread_mutex_unlock(&table->meal);
-			i++;
-		}
-	}
-	return (NULL);
+            return (1);
+        }
+        pthread_mutex_unlock(&table->meal);
+        i++;
+    }
+    return (0);
+}
+
+static void *monitor(void *arg)
+{
+    t_table *table;
+
+    table = (t_table *)arg;
+    while (1)
+    {
+        if (!is_kitchen_open(table))
+            return (NULL);
+        if (all_philos_full(table))
+            return (NULL);
+		if(philo_is_dead(table))
+			return (NULL);
+    }
+    return (NULL);
 }
 
 static void	create_threads(t_table *table)
@@ -96,3 +101,4 @@ void	handle_routine(t_table *table)
 	}
 	pthread_join(table->waiter, NULL);
 }
+

--- a/philo/src/threads.c
+++ b/philo/src/threads.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 22:12:59 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 22:20:18 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,18 +37,16 @@ static int all_philos_full(t_table *table)
 static int philo_is_dead(t_table *table)
 {
     int i;
-    uint64_t t_now;
 
     i = 0;
-    t_now = get_time();
     while (i < table->n_philos)
     {
         pthread_mutex_lock(&table->meal);
-        if ((t_now - table->philos[i].t_last_meal) > (uint64_t)table->t_die)
+        if ((get_time() - table->philos[i].t_last_meal) > (uint64_t)table->t_die)
         {
-			table->kitchen_open = 0;
-			microphone(table, "died", i);
 			pthread_mutex_unlock(&table->meal);
+			microphone(table, "died", i);
+			table->kitchen_open = 0;
             return (1);
         }
         pthread_mutex_unlock(&table->meal);

--- a/philo/src/utils.c
+++ b/philo/src/utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 15:19:24 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/19 15:27:29 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/19 21:45:08 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,18 +57,17 @@ void	lock_forks(t_philo *philo, int id)
 	int	nb_philo;
 
 	nb_philo = philo->table->n_philos;
-	if (id % 2 == 0)
+	if (id % 2 != 0)
 	{
 		pthread_mutex_lock(&philo->fork);
 		pthread_mutex_lock(&philo->table->philos[(id + 1) % nb_philo].fork);
-		microphone(philo->table, "has taken a fork", philo->id);
 	}
 	else
 	{
 		pthread_mutex_lock(&philo->table->philos[(id + 1) % nb_philo].fork);
 		pthread_mutex_lock(&philo->fork);
-		microphone(philo->table, "has taken a fork", philo->id);
 	}
+	microphone(philo->table, "has taken a fork", philo->id);
 }
 
 void	unlock_forks(t_philo *philo, int id)
@@ -76,7 +75,7 @@ void	unlock_forks(t_philo *philo, int id)
 	int	nb_philo;
 
 	nb_philo = philo->table->n_philos;
-	if (id % 2 == 0)
+	if (id % 2 != 0)
 	{
 		pthread_mutex_unlock(&philo->table->philos[(id + 1) % nb_philo].fork);
 		pthread_mutex_unlock(&philo->fork);


### PR DESCRIPTION
This update adds a third mutex called `meal` which is used whenever we need to check the status of `n_meals`, `t_last_meal` or `kitchen_is_open`.

Before this update, these variables were get or set without using a mutex and this is not thread-safe. Now we stop execution until these are evaluated in isolation.

As I added checks the code became long and repetitive, so I created some helper functions, especially simplifying the monitor function.