### PR TITLE
♻️ refactor: new stress test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/09/16 12:01:03 by pmarkaid          #+#    #+#              #
-#    Updated: 2024/09/19 10:52:12 by pmarkaid         ###   ########.fr        #
+#    Updated: 2024/09/30 13:42:01 by pmarkaid         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -16,7 +16,7 @@ SRCS_FILES =                        \
 	main.c 							\
 	utils.c							\
 	routine.c						\
-	threads.c
+	monitor.c
 
 SRC_DIR = src/
 SRCS = $(addprefix $(SRC_DIR), $(SRCS_FILES))

--- a/include/philo.h
+++ b/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 12:13:14 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 13:25:56 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,6 +44,7 @@ typedef struct s_table
 	int					kitchen_open;
 	int					n_philos;
 	int					n_meals;
+	int					full_philos;
 	uint64_t			t_die;
 	uint64_t			t_eat;
 	uint64_t			t_sleep;

--- a/include/philo.h
+++ b/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/23 15:53:23 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 12:13:14 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,10 +43,10 @@ typedef struct s_table
 {
 	int					kitchen_open;
 	int					n_philos;
-	int					t_die;
-	int					t_eat;
-	int					t_sleep;
 	int					n_meals;
+	uint64_t			t_die;
+	uint64_t			t_eat;
+	uint64_t			t_sleep;
 	pthread_t			waiter;
 	pthread_mutex_t		microphone;
 	pthread_mutex_t		meal;

--- a/include/philo.h
+++ b/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 13:25:56 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 14:37:52 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,8 +61,6 @@ t_table					*init_table(char **argv);
 int						ft_atoi(const char *str);
 void					*routine(void *arg);
 void					handle_routine(t_table *table);
-void					lock_forks(t_philo *philo, int id);
-void					unlock_forks(t_philo *philo, int id);
 void					clean_data(t_table *table);
 void					microphone(t_table *table, char *msg, int id);
 int						kitchen_is_open(t_table *table);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/23 15:56:22 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 13:28:00 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,10 +71,11 @@ t_table	*init_table(char **argv)
 	table = (t_table *)malloc(sizeof(t_table));
 	table->kitchen_open = 1;
 	table->n_philos = ft_atoi(argv[1]);
+	table->n_meals = ft_atoi(argv[5]);
+	table->full_philos = 0;
 	table->t_die = ft_atoi(argv[2]);
 	table->t_eat = ft_atoi(argv[3]);
 	table->t_sleep = ft_atoi(argv[4]);
-	table->n_meals = ft_atoi(argv[5]);
 	table->philos = (t_philo *)malloc(sizeof(t_philo) * table->n_philos);
 	table->t_start = get_time();
 	while (i < table->n_philos)

--- a/src/routine.c
+++ b/src/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 13:22:03 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 13:32:33 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,8 @@ static void	eat(t_philo *philo, int t_eat)
 	pthread_mutex_lock(&philo->table->meal);
 	philo->t_last_meal = get_time();
 	philo->n_meals++;
+	if(philo->n_meals == philo->table->n_meals)
+		philo->table->full_philos++;
 	pthread_mutex_unlock(&philo->table->meal);
 	microphone(philo->table, "is eating", philo->id);
 	ft_usleep(t_eat);
@@ -53,7 +55,7 @@ void	*routine(void *arg)
 {
 	t_philo	*philo;
 	t_table	*table;
-	int n_meals;
+	int		n_meals;
 
 	philo = (t_philo *)arg;
 	table = philo->table;
@@ -70,7 +72,7 @@ void	*routine(void *arg)
 			pthread_mutex_lock(&table->meal);
 			n_meals = philo->n_meals;
 			pthread_mutex_unlock(&table->meal);
-			if(n_meals >= table->n_meals)
+			if (n_meals >= table->n_meals)
 				break ;
 		}
 		go_sleep(philo, table->t_sleep);

--- a/src/routine.c
+++ b/src/routine.c
@@ -6,24 +6,53 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 14:30:44 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 14:37:29 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
 
-void	ft_usleep(uint64_t sleep_time)
+static void	lock_forks(t_philo *philo, int id)
 {
-	uint64_t	start;
+	int	n_philo;
 
-	start = get_time();
-	while ((get_time() - start) < sleep_time)
-		usleep(500);
+	n_philo = philo->table->n_philos;
+	if (id % 2 == 0)
+	{
+		pthread_mutex_lock(&philo->fork);
+		microphone(philo->table, "has taken a fork", philo->id);
+		pthread_mutex_lock(&philo->table->philos[(id + 1) % n_philo].fork);
+		microphone(philo->table, "has taken a fork", philo->id);
+	}
+	else
+	{
+		pthread_mutex_lock(&philo->table->philos[(id + 1) % n_philo].fork);
+		microphone(philo->table, "has taken a fork", philo->id);
+		pthread_mutex_lock(&philo->fork);
+		microphone(philo->table, "has taken a fork", philo->id);
+	}
+}
+
+static void	unlock_forks(t_philo *philo, int id)
+{
+	int	n_philo;
+
+	n_philo = philo->table->n_philos;
+	if (id % 2 == 0)
+	{
+		pthread_mutex_unlock(&philo->table->philos[(id + 1) % n_philo].fork);
+		pthread_mutex_unlock(&philo->fork);
+	}
+	else
+	{
+		pthread_mutex_unlock(&philo->fork);
+		pthread_mutex_unlock(&philo->table->philos[(id + 1) % n_philo].fork);
+	}
 }
 
 static int	eat(t_philo *philo, int t_eat)
 {
-	int n_meals;
+	int	n_meals;
 
 	lock_forks(philo, philo->id);
 	pthread_mutex_lock(&philo->table->meal);
@@ -33,7 +62,7 @@ static int	eat(t_philo *philo, int t_eat)
 	microphone(philo->table, "is eating", philo->id);
 	ft_usleep(t_eat);
 	unlock_forks(philo, philo->id);
-	if(philo->table->n_meals > 0)
+	if (philo->table->n_meals > 0)
 	{
 		pthread_mutex_lock(&philo->table->meal);
 		n_meals = philo->n_meals;
@@ -44,7 +73,7 @@ static int	eat(t_philo *philo, int t_eat)
 			return (1);
 		}
 	}
-	return(0);
+	return (0);
 }
 
 static void	go_sleep(t_philo *philo, int t_sleep)
@@ -65,10 +94,10 @@ void	*routine(void *arg)
 		if (!kitchen_is_open(table))
 			break ;
 		microphone(table, "is thinking", philo->id);
-		if (philo->id % 2 != 0 && philo->n_meals == 0)
+		if (philo->id % 2 == 0 && philo->n_meals == 0)
 			ft_usleep(table->t_eat / 2);
-		if(eat(philo, table->t_eat))
-			break;
+		if (eat(philo, table->t_eat))
+			break ;
 		go_sleep(philo, table->t_sleep);
 	}
 	return (NULL);

--- a/src/routine.c
+++ b/src/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 12:35:17 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 13:22:03 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,6 +62,8 @@ void	*routine(void *arg)
 		if (!kitchen_is_open(table))
 			break ;
 		microphone(table, "is thinking", philo->id);
+		if (philo->id % 2 != 0 && philo->n_meals == 0)
+			ft_usleep(table->t_eat / 2);
 		eat(philo, table->t_eat);
 		if (table->n_meals > 0)
 		{

--- a/src/routine.c
+++ b/src/routine.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 16:30:10 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/23 15:53:23 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 12:35:17 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,7 @@ void	*routine(void *arg)
 {
 	t_philo	*philo;
 	t_table	*table;
+	int n_meals;
 
 	philo = (t_philo *)arg;
 	table = philo->table;
@@ -62,13 +63,14 @@ void	*routine(void *arg)
 			break ;
 		microphone(table, "is thinking", philo->id);
 		eat(philo, table->t_eat);
-		pthread_mutex_lock(&table->meal);
-		if (table->n_meals > 0 && philo->n_meals >= table->n_meals)
+		if (table->n_meals > 0)
 		{
+			pthread_mutex_lock(&table->meal);
+			n_meals = philo->n_meals;
 			pthread_mutex_unlock(&table->meal);
-			break ;
+			if(n_meals >= table->n_meals)
+				break ;
 		}
-		pthread_mutex_unlock(&table->meal);
 		go_sleep(philo, table->t_sleep);
 	}
 	return (NULL);

--- a/src/threads.c
+++ b/src/threads.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/23 15:59:26 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 11:50:05 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,7 @@ static int	all_philos_full(t_table *table)
 static int	philo_is_dead(t_table *table)
 {
 	int			i;
-	uint16_t	t_now;
+	uint64_t	t_now;
 
 	i = 0;
 	while (i < table->n_philos)
@@ -70,9 +70,6 @@ static void	*monitor(void *arg)
 	table = (t_table *)arg;
 	while (1)
 	{
-		ft_usleep(1);
-		if (!kitchen_is_open(table))
-			break ;
 		if (philo_is_dead(table))
 			break ;
 		if (all_philos_full(table))

--- a/src/threads.c
+++ b/src/threads.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 11:50:05 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 12:18:59 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,30 +34,33 @@ static int	all_philos_full(t_table *table)
 	return (1);
 }
 
-static int	philo_is_dead(t_table *table)
+static int	is_philo_dead(t_table *table, t_philo *philo)
+{
+	pthread_mutex_lock(&table->meal);
+	if (get_time() - philo->t_last_meal >= table->t_die)
+	{
+		pthread_mutex_unlock(&table->meal);
+		return (1);
+	}
+	pthread_mutex_unlock(&table->meal);
+	return (0);
+}
+
+static int	any_philo_died(t_table *table)
 {
 	int			i;
-	uint64_t	t_now;
 
 	i = 0;
 	while (i < table->n_philos)
 	{
-		pthread_mutex_lock(&table->meal);
-		if (table->philos[i].n_meals == table->n_meals)
+		if (is_philo_dead(table, &table->philos[i]))
 		{
-			i++;
-			pthread_mutex_unlock(&table->meal);
-			continue ;
-		}
-		t_now = get_time();
-		if ((t_now - table->philos[i].t_last_meal) > (uint64_t)table->t_die)
-		{
-			printf("%ld %d died\n", t_now - table->t_start, i + 1);
+			pthread_mutex_lock(&table->meal);
 			table->kitchen_open = 0;
 			pthread_mutex_unlock(&table->meal);
+			printf("%ld %d died\n", get_time() - table->t_start, i + 1);
 			return (1);
 		}
-		pthread_mutex_unlock(&table->meal);
 		i++;
 	}
 	return (0);
@@ -70,7 +73,7 @@ static void	*monitor(void *arg)
 	table = (t_table *)arg;
 	while (1)
 	{
-		if (philo_is_dead(table))
+		if (any_philo_died(table))
 			break ;
 		if (all_philos_full(table))
 			break ;

--- a/src/threads.c
+++ b/src/threads.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 12:18:59 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 12:36:11 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,13 +36,13 @@ static int	all_philos_full(t_table *table)
 
 static int	is_philo_dead(t_table *table, t_philo *philo)
 {
+	int64_t t_meal;
+
 	pthread_mutex_lock(&table->meal);
-	if (get_time() - philo->t_last_meal >= table->t_die)
-	{
-		pthread_mutex_unlock(&table->meal);
-		return (1);
-	}
+	t_meal = philo->t_last_meal;
 	pthread_mutex_unlock(&table->meal);
+	if (get_time() - t_meal >= table->t_die)
+		return (1);
 	return (0);
 }
 

--- a/src/threads.c
+++ b/src/threads.c
@@ -6,49 +6,27 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 12:36:11 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 13:37:21 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
 
-static int	all_philos_full(t_table *table)
-{
-	int	i;
-
-	if (table->n_meals == 0)
-		return (0);
-	pthread_mutex_lock(&table->meal);
-	i = 0;
-	while (i < table->n_philos)
-	{
-		if (table->philos[i].n_meals < table->n_meals)
-		{
-			pthread_mutex_unlock(&table->meal);
-			return (0);
-		}
-		i++;
-	}
-	table->kitchen_open = 0;
-	pthread_mutex_unlock(&table->meal);
-	return (1);
-}
-
 static int	is_philo_dead(t_table *table, t_philo *philo)
 {
-	int64_t t_meal;
+	int64_t	t_last_meal;
 
 	pthread_mutex_lock(&table->meal);
-	t_meal = philo->t_last_meal;
+	t_last_meal = philo->t_last_meal;
 	pthread_mutex_unlock(&table->meal);
-	if (get_time() - t_meal >= table->t_die)
+	if (get_time() - t_last_meal >= table->t_die)
 		return (1);
 	return (0);
 }
 
 static int	any_philo_died(t_table *table)
 {
-	int			i;
+	int	i;
 
 	i = 0;
 	while (i < table->n_philos)
@@ -69,14 +47,27 @@ static int	any_philo_died(t_table *table)
 static void	*monitor(void *arg)
 {
 	t_table	*table;
+	int		full_philos;
 
 	table = (t_table *)arg;
 	while (1)
 	{
+		ft_usleep(1);
 		if (any_philo_died(table))
 			break ;
-		if (all_philos_full(table))
-			break ;
+		if(table->n_meals > 0)
+		{
+			pthread_mutex_lock(&table->meal);
+			full_philos = table->full_philos;
+			pthread_mutex_unlock(&table->meal);
+			if (full_philos == table->n_philos)
+			{
+				pthread_mutex_lock(&table->meal);
+				table->kitchen_open = 0;
+				pthread_mutex_unlock(&table->meal);
+				break ;
+			}
+		}
 	}
 	return (NULL);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 15:19:24 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/23 15:54:37 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 13:21:14 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,7 @@ void	lock_forks(t_philo *philo, int id)
 	int	n_philo;
 
 	n_philo = philo->table->n_philos;
-	if (id % 2 != 0)
+	if (id % 2 == 0)
 	{
 		pthread_mutex_lock(&philo->fork);
 		microphone(philo->table, "has taken a fork", philo->id);
@@ -78,7 +78,7 @@ void	unlock_forks(t_philo *philo, int id)
 	int	n_philo;
 
 	n_philo = philo->table->n_philos;
-	if (id % 2 != 0)
+	if (id % 2 == 0)
 	{
 		pthread_mutex_unlock(&philo->table->philos[(id + 1) % n_philo].fork);
 		pthread_mutex_unlock(&philo->fork);

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,11 +6,28 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 15:19:24 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 13:21:14 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/09/30 14:38:19 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
+
+uint64_t	get_time(void)
+{
+	struct timeval	time;
+
+	gettimeofday(&time, NULL);
+	return ((uint64_t)time.tv_sec * 1000 + time.tv_usec / 1000);
+}
+
+void	ft_usleep(uint64_t sleep_time)
+{
+	uint64_t	start;
+
+	start = get_time();
+	while ((get_time() - start) < sleep_time)
+		usleep(500);
+}
 
 void	clean_data(t_table *table)
 {
@@ -50,50 +67,4 @@ int	ft_atoi(const char *str)
 			return (-1);
 	}
 	return (nb * neg);
-}
-
-void	lock_forks(t_philo *philo, int id)
-{
-	int	n_philo;
-
-	n_philo = philo->table->n_philos;
-	if (id % 2 == 0)
-	{
-		pthread_mutex_lock(&philo->fork);
-		microphone(philo->table, "has taken a fork", philo->id);
-		pthread_mutex_lock(&philo->table->philos[(id + 1) % n_philo].fork);
-		microphone(philo->table, "has taken a fork", philo->id);
-	}
-	else
-	{
-		pthread_mutex_lock(&philo->table->philos[(id + 1) % n_philo].fork);
-		microphone(philo->table, "has taken a fork", philo->id);
-		pthread_mutex_lock(&philo->fork);
-		microphone(philo->table, "has taken a fork", philo->id);
-	}
-}
-
-void	unlock_forks(t_philo *philo, int id)
-{
-	int	n_philo;
-
-	n_philo = philo->table->n_philos;
-	if (id % 2 == 0)
-	{
-		pthread_mutex_unlock(&philo->table->philos[(id + 1) % n_philo].fork);
-		pthread_mutex_unlock(&philo->fork);
-	}
-	else
-	{
-		pthread_mutex_unlock(&philo->fork);
-		pthread_mutex_unlock(&philo->table->philos[(id + 1) % n_philo].fork);
-	}
-}
-
-uint64_t	get_time(void)
-{
-	struct timeval	time;
-
-	gettimeofday(&time, NULL);
-	return ((uint64_t)time.tv_sec * 1000 + time.tv_usec / 1000);
 }


### PR DESCRIPTION
This update improves the use of locks, making the runtime much more efficient.

The mutexes are reevaluated and used only when needed. For example, if before we evaluate the time difference between `now` and `t_last_meal`, we now get and save the value of `t_last_meal`  in between the mutexes, but the comparison is done *outside* mutexes.

In the same context, a big change is in the "philo is dead" check. Instead of iterating through all the philos inside the mutex and checking for deaths, we evaluate one by one and open the mutex for that particular one. The rest of the thread get the mutex free to continue.

The evaluation to see if all philos are full is also simplified, checking a flag with the mutex.

Other optimizations include improving the beginning of the execution, adding a certain amount of thinking time or the fork taking order.

