### PR TITLE
🐛 fix: correct eval failures

### DIFF
--- a/include/philo.h
+++ b/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 15:39:04 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 15:24:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,7 @@ int						ft_atoi(const char *str);
 void					*routine(void *arg);
 void					handle_routine(t_table *table);
 void					microphone(t_table *table, char *msg, int id);
-void					handle_one_philo(t_table *table);
+int						handle_one_philo(t_table *table);
 void					ft_usleep(uint64_t sleep_time);
 
 #endif /* PHILO_H */

--- a/include/philo.h
+++ b/include/philo.h
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:01:07 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/03 15:24:09 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 16:01:56 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@
 # include <pthread.h>  // pthread functions
 # include <stdint.h>   // uint64_t
 # include <stdio.h>    // printf
-# include <stdlib.h>   // memset, malloc, free
+# include <stdlib.h>   // malloc, free
 # include <sys/time.h> // gettimeofday
 # include <unistd.h>   // write, usleep
 
@@ -52,7 +52,7 @@ int						eval_args(int argc, char **argv);
 void					clean_data(t_table *table);
 int						ft_atoi(const char *str);
 void					*routine(void *arg);
-void					handle_routine(t_table *table);
+int						handle_routine(t_table *table);
 void					microphone(t_table *table, char *msg, int id);
 int						handle_one_philo(t_table *table);
 void					ft_usleep(uint64_t sleep_time);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/03 16:02:09 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 16:23:50 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,10 +33,7 @@ int	main(int argc, char **argv)
 		write(2, "ERROR: malloc failed\n", 21);
 		return (1);
 	}
-	if (table->n_philos == 1)
-		status = handle_one_philo(table);
-	else
-		status = handle_routine(table);
+	status = handle_routine(table);
 	clean_data(table);
 	return (status);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 15:38:14 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/01 15:08:11 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,13 +16,13 @@ int	main(int argc, char **argv)
 {
 	t_table	*table;
 
-	eval_args(argc, argv);
 	if (argc != 5 && argc != 6)
 	{
-		printf("Usage:\n");
-		printf("\t./philo n_philo t_die t_eat t_sleep [n_meals]\n");
+		write(2, "Usage:\n", 7);
+		write(2, "\t./philo n_philo t_die t_eat t_sleep [n_meals]\n", 47);
 		return (1);
 	}
+	eval_args(argc, argv);
 	if (argc == 5)
 		argv[5] = "0";
 	table = init_table(argv);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/01 15:17:12 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 16:02:09 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 int	main(int argc, char **argv)
 {
 	t_table	*table;
+	int		status;
 
 	if (argc != 5 && argc != 6)
 	{
@@ -33,9 +34,9 @@ int	main(int argc, char **argv)
 		return (1);
 	}
 	if (table->n_philos == 1)
-		handle_one_philo(table);
+		status = handle_one_philo(table);
 	else
-		handle_routine(table);
+		status = handle_routine(table);
 	clean_data(table);
-	return (0);
+	return (status);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/16 12:00:59 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/01 15:08:11 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/01 15:17:12 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,12 @@ int	main(int argc, char **argv)
 	if (argc == 5)
 		argv[5] = "0";
 	table = init_table(argv);
+	if (!table)
+	{
+		clean_data(table);
+		write(2, "ERROR: malloc failed\n", 21);
+		return (1);
+	}
 	if (table->n_philos == 1)
 		handle_one_philo(table);
 	else

--- a/src/main_utils.c
+++ b/src/main_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 15:38:02 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 15:40:58 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/01 15:09:35 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,14 +75,14 @@ int	eval_args(int argc, char **argv)
 		{
 			if (argv[i][j] < '0' || argv[i][j] > '9')
 			{
-				printf("ERROR: arguments must be positive integers\n");
+				write(2, "ERROR: arguments must be positive integers\n", 43);
 				exit(1);
 			}
 			j++;
 		}
 		if (ft_atoi(argv[i]) == 0 || ft_atoi(argv[i]) == -1)
 		{
-			printf("ERROR: use a number between 1 and INT_MAX\n");
+			write(2, "ERROR: use a number between 1 and INT_MAX\n", 42);
 			exit(1);
 		}
 		i++;

--- a/src/main_utils.c
+++ b/src/main_utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 15:38:02 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/01 15:09:35 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/01 15:16:29 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,8 @@ t_table	*init_table(char **argv)
 	t_table	*table;
 
 	table = (t_table *)malloc(sizeof(t_table));
+	if (!table)
+		return (NULL);
 	table->kitchen_open = 1;
 	table->n_philos = ft_atoi(argv[1]);
 	table->n_meals = ft_atoi(argv[5]);
@@ -41,6 +43,8 @@ t_table	*init_table(char **argv)
 	table->t_eat = ft_atoi(argv[3]);
 	table->t_sleep = ft_atoi(argv[4]);
 	table->philos = (t_philo *)malloc(sizeof(t_philo) * table->n_philos);
+	if (!table->philos)
+		return (NULL);
 	table->t_start = get_time();
 	init_philos(table);
 	pthread_mutex_init(&table->microphone, NULL);
@@ -52,14 +56,22 @@ void	clean_data(t_table *table)
 {
 	int	i;
 
-	i = 0;
-	while (i < table->n_philos)
+	if (table)
 	{
-		pthread_mutex_destroy(&table->philos[i].fork);
-		i++;
+		if (table->philos)
+		{
+			i = 0;
+			while (i < table->n_philos)
+			{
+				pthread_mutex_destroy(&table->philos[i].fork);
+				i++;
+			}
+			free(table->philos);
+		}
+		pthread_mutex_destroy(&table->microphone);
+		pthread_mutex_destroy(&table->meal);
+		free(table);
 	}
-	free(table->philos);
-	free(table);
 }
 
 int	eval_args(int argc, char **argv)

--- a/src/main_utils.c
+++ b/src/main_utils.c
@@ -6,13 +6,13 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 15:38:02 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/03 16:16:20 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 16:27:32 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
 
-static void	*init_philos(t_table *table)
+static int	init_philos(t_table *table)
 {
 	int	i;
 
@@ -24,9 +24,10 @@ static void	*init_philos(t_table *table)
 		table->philos[i].n_meals = 0;
 		table->philos[i].t_last_meal = get_time();
 		if (pthread_mutex_init(&table->philos[i].fork, NULL) != 0)
-			return (NULL);
+			return (1);
 		i++;
 	}
+	return (0);
 }
 
 t_table	*init_table(char **argv)
@@ -47,7 +48,7 @@ t_table	*init_table(char **argv)
 	table->philos = (t_philo *)malloc(sizeof(t_philo) * table->n_philos);
 	if (!table->philos)
 		return (NULL);
-	if (!init_philos(table))
+	if (init_philos(table) != 0)
 		return (NULL);
 	if (pthread_mutex_init(&table->microphone, NULL) != 0)
 		return (NULL);

--- a/src/main_utils.c
+++ b/src/main_utils.c
@@ -6,13 +6,13 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 15:38:02 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/01 15:16:29 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 16:16:20 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
 
-static void	init_philos(t_table *table)
+static void	*init_philos(t_table *table)
 {
 	int	i;
 
@@ -23,7 +23,8 @@ static void	init_philos(t_table *table)
 		table->philos[i].table = table;
 		table->philos[i].n_meals = 0;
 		table->philos[i].t_last_meal = get_time();
-		pthread_mutex_init(&table->philos[i].fork, NULL);
+		if (pthread_mutex_init(&table->philos[i].fork, NULL) != 0)
+			return (NULL);
 		i++;
 	}
 }
@@ -42,13 +43,16 @@ t_table	*init_table(char **argv)
 	table->t_die = ft_atoi(argv[2]);
 	table->t_eat = ft_atoi(argv[3]);
 	table->t_sleep = ft_atoi(argv[4]);
+	table->t_start = get_time();
 	table->philos = (t_philo *)malloc(sizeof(t_philo) * table->n_philos);
 	if (!table->philos)
 		return (NULL);
-	table->t_start = get_time();
-	init_philos(table);
-	pthread_mutex_init(&table->microphone, NULL);
-	pthread_mutex_init(&table->meal, NULL);
+	if (!init_philos(table))
+		return (NULL);
+	if (pthread_mutex_init(&table->microphone, NULL) != 0)
+		return (NULL);
+	if (pthread_mutex_init(&table->meal, NULL) != 0)
+		return (NULL);
 	return (table);
 }
 

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -6,21 +6,11 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 16:23:04 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 15:19:48 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "philo.h"
-
-void	handle_one_philo(t_table *table)
-{
-	pthread_create(&table->philos[0].th, NULL, routine,
-		(void *)&table->philos[0]);
-	pthread_mutex_lock(&table->philos[0].fork);
-	microphone(table, "has taken a fork", 0);
-	ft_usleep(table->t_die);
-	microphone(table, "died", 0);
-}
 
 static int	is_philo_dead(t_table *table, t_philo *philo)
 {

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/03 16:07:15 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 16:24:14 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -106,6 +106,8 @@ int	handle_routine(t_table *table)
 {
 	int	i;
 
+	if (table->n_philos == 1)
+		return (handle_one_philo(table));
 	i = 0;
 	if (create_threads(table))
 		return (1);

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/18 09:37:41 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/03 16:04:51 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 16:07:15 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,7 +79,7 @@ static void	*monitor(void *arg)
 	return (NULL);
 }
 
-int	create_threads(t_table *table)
+static int	create_threads(t_table *table)
 {
 	int	i;
 
@@ -107,6 +107,8 @@ int	handle_routine(t_table *table)
 	int	i;
 
 	i = 0;
+	if (create_threads(table))
+		return (1);
 	while (i < table->n_philos)
 	{
 		if (pthread_join(table->philos[i].th, NULL) != 0)

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 15:19:24 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/10/03 15:25:36 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 16:41:57 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,7 +63,16 @@ int	handle_one_philo(t_table *table)
 {
 	pthread_t	philo_thread;
 
-	pthread_create(&philo_thread, NULL, one_philo, (void *)&table->philos[0]);
-	pthread_join(philo_thread, NULL);
+	if (pthread_create(&philo_thread, NULL, one_philo,
+			(void *)&table->philos[0]) != 0)
+	{
+		write(2, "Failed to create one philo thread\n", 34);
+		return (1);
+	}
+	if (pthread_join(philo_thread, NULL) != 0)
+	{
+		write(2, "Failed to join one philo thread\n", 32);
+		return (1);
+	}
 	return (0);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -6,7 +6,7 @@
 /*   By: pmarkaid <pmarkaid@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/17 15:19:24 by pmarkaid          #+#    #+#             */
-/*   Updated: 2024/09/30 16:24:33 by pmarkaid         ###   ########.fr       */
+/*   Updated: 2024/10/03 15:25:36 by pmarkaid         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,4 +43,27 @@ void	microphone(t_table *table, char *msg, int id)
 	pthread_mutex_lock(&table->microphone);
 	printf("%ld %d %s\n", t_stamp, id + 1, msg);
 	pthread_mutex_unlock(&table->microphone);
+}
+
+static void	*one_philo(void *arg)
+{
+	t_philo	*philo;
+	t_table	*table;
+
+	philo = (t_philo *)arg;
+	table = philo->table;
+	pthread_mutex_lock(&philo->fork);
+	microphone(table, "has taken a fork", philo->id);
+	ft_usleep(table->t_die);
+	microphone(table, "died", philo->id);
+	return (NULL);
+}
+
+int	handle_one_philo(t_table *table)
+{
+	pthread_t	philo_thread;
+
+	pthread_create(&philo_thread, NULL, one_philo, (void *)&table->philos[0]);
+	pthread_join(philo_thread, NULL);
+	return (0);
 }


### PR DESCRIPTION
This fix adds some corrections after the eval failed due to the one Philo leak.

From most important to less important:

- One philo is handled on a separate thread and joined appropriately
- Protect thread creation and mutex initialization
- Protect mallocs
- Error messages printed to `stderr`
